### PR TITLE
Fix react-router-dom import

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route } from "react-router";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { AuthProvider, ProtectedRoute } from "@/components/auth";
 import { ToastProvider } from "@/contexts/ToastContext";
 import Layout from "@/components/layout/Layout";


### PR DESCRIPTION
Replace 'react-router' import with 'react-router-dom' 
BrowserRouter, Routes, and Route are exported from react-router-dom

  ## Test plan
  - Verify that the
  application builds and runs
   without import errors
  - Confirm routing
  functionality works as
  expected

Adjusts runtime/build
  error where the import was
  referencing the wrong
  package.