### PR TITLE
Safari balks at adding generated API key to clipboard

### DIFF
--- a/frontend/src/components/auth/ApiKeyCopyButton.tsx
+++ b/frontend/src/components/auth/ApiKeyCopyButton.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Copy, Check } from 'lucide-react';
-import { useToast } from '@/hooks/useToast';
-import { authApi } from '@/lib/api';
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Copy, Check } from "lucide-react";
+import { useToast } from "@/hooks/useToast";
+import { authApi } from "@/lib/api";
 
 export function ApiKeyCopyButton() {
 	const [copied, setCopied] = useState(false);
@@ -21,11 +21,11 @@ export function ApiKeyCopyButton() {
 				// context alive while the fetch resolves, so Safari accepts the write.
 				await navigator.clipboard.write([
 					new ClipboardItem({
-						'text/plain': authApi.generateNewApiKey().then((response) => {
+						"text/plain": authApi.generateNewApiKey().then((response) => {
 							if (!response.success || !response.apiKey?.key) {
-								throw new Error('Failed to generate API key');
+								throw new Error("Failed to generate API key");
 							}
-							return new Blob([response.apiKey.key], { type: 'text/plain' });
+							return new Blob([response.apiKey.key], { type: "text/plain" });
 						})
 					})
 				]);
@@ -34,29 +34,29 @@ export function ApiKeyCopyButton() {
 				const response = await authApi.generateNewApiKey();
 
 				if (!response.success || !response.apiKey?.key) {
-					throw new Error('Failed to generate API key');
+					throw new Error("Failed to generate API key");
 				}
 
-				const textArea = document.createElement('textarea');
+				const textArea = document.createElement("textarea");
 				textArea.value = response.apiKey.key;
-				textArea.style.position = 'fixed';
-				textArea.style.left = '-999999px';
-				textArea.style.top = '-999999px';
+				textArea.style.position = "fixed";
+				textArea.style.left = "-999999px";
+				textArea.style.top = "-999999px";
 				document.body.appendChild(textArea);
 				textArea.focus();
 				textArea.select();
-				document.execCommand('copy');
+				document.execCommand("copy");
 				textArea.remove();
 			}
 
 			setCopied(true);
-			toast.success('New API key copied to clipboard!');
+			toast.success("New API key copied to clipboard!");
 
 			// Reset the copied state after 2 seconds
 			setTimeout(() => setCopied(false), 2000);
 		} catch (error) {
-			console.error('Failed to copy API key:', error);
-			toast.error('Failed to generate and copy API key');
+			console.error("Failed to copy API key:", error);
+			toast.error("Failed to generate and copy API key");
 		} finally {
 			setLoading(false);
 		}
@@ -78,7 +78,7 @@ export function ApiKeyCopyButton() {
 			) : (
 				<>
 					<Copy className="h-4 w-4" />
-					{loading ? 'Generating...' : 'Copy API Key'}
+					{loading ? "Generating..." : "Copy API Key"}
 				</>
 			)}
 		</Button>

--- a/frontend/src/components/auth/ApiKeyCopyButton.tsx
+++ b/frontend/src/components/auth/ApiKeyCopyButton.tsx
@@ -1,78 +1,86 @@
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { Copy, Check } from "lucide-react";
-import { useToast } from "@/hooks/useToast";
-import { authApi } from "@/lib/api";
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Copy, Check } from 'lucide-react';
+import { useToast } from '@/hooks/useToast';
+import { authApi } from '@/lib/api';
 
 export function ApiKeyCopyButton() {
-  const [copied, setCopied] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const toast = useToast();
+	const [copied, setCopied] = useState(false);
+	const [loading, setLoading] = useState(false);
+	const toast = useToast();
 
-  const handleCopyApiKey = async () => {
-    if (loading) return;
-    
-    setLoading(true);
-    
-    try {
-      // Generate a new API key (this invalidates previous keys)
-      const response = await authApi.generateNewApiKey();
-      
-      if (!response.success || !response.apiKey?.key) {
-        throw new Error("Failed to generate API key");
-      }
+	const handleCopyApiKey = async () => {
+		if (loading) return;
 
-      const apiKey = response.apiKey.key;
+		setLoading(true);
 
-      // Copy to clipboard
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        await navigator.clipboard.writeText(apiKey);
-      } else {
-        // Fallback for older browsers
-        const textArea = document.createElement("textarea");
-        textArea.value = apiKey;
-        textArea.style.position = "fixed";
-        textArea.style.left = "-999999px";
-        textArea.style.top = "-999999px";
-        document.body.appendChild(textArea);
-        textArea.focus();
-        textArea.select();
-        document.execCommand("copy");
-        textArea.remove();
-      }
+		try {
+			if (navigator.clipboard && window.ClipboardItem) {
+				// Safari requires clipboard writes to be initiated synchronously within a
+				// user gesture. Passing a Promise as ClipboardItem data keeps the gesture
+				// context alive while the fetch resolves, so Safari accepts the write.
+				await navigator.clipboard.write([
+					new ClipboardItem({
+						'text/plain': authApi.generateNewApiKey().then((response) => {
+							if (!response.success || !response.apiKey?.key) {
+								throw new Error('Failed to generate API key');
+							}
+							return new Blob([response.apiKey.key], { type: 'text/plain' });
+						})
+					})
+				]);
+			} else {
+				// Fallback for older browsers without the Clipboard API
+				const response = await authApi.generateNewApiKey();
 
-      setCopied(true);
-      toast.success("New API key copied to clipboard!");
-      
-      // Reset the copied state after 2 seconds
-      setTimeout(() => setCopied(false), 2000);
-    } catch (error) {
-      console.error("Failed to copy API key:", error);
-      toast.error("Failed to generate and copy API key");
-    } finally {
-      setLoading(false);
-    }
-  };
+				if (!response.success || !response.apiKey?.key) {
+					throw new Error('Failed to generate API key');
+				}
 
-  return (
-    <Button
-      variant="outline"
-      size="sm"
-      onClick={handleCopyApiKey}
-      disabled={loading}
-      className="gap-2"
-    >
-      {copied ? (
-        <>
-          <Check className="h-4 w-4" />
-          Copied!
-        </>
-      ) : (
-        <>
-          <Copy className="h-4 w-4" />
-          {loading ? "Generating..." : "Copy API Key"}
-        </>
-      )}
-    </Button>
-  );
+				const textArea = document.createElement('textarea');
+				textArea.value = response.apiKey.key;
+				textArea.style.position = 'fixed';
+				textArea.style.left = '-999999px';
+				textArea.style.top = '-999999px';
+				document.body.appendChild(textArea);
+				textArea.focus();
+				textArea.select();
+				document.execCommand('copy');
+				textArea.remove();
+			}
+
+			setCopied(true);
+			toast.success('New API key copied to clipboard!');
+
+			// Reset the copied state after 2 seconds
+			setTimeout(() => setCopied(false), 2000);
+		} catch (error) {
+			console.error('Failed to copy API key:', error);
+			toast.error('Failed to generate and copy API key');
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	return (
+		<Button
+			variant="outline"
+			size="sm"
+			onClick={handleCopyApiKey}
+			disabled={loading}
+			className="gap-2"
+		>
+			{copied ? (
+				<>
+					<Check className="h-4 w-4" />
+					Copied!
+				</>
+			) : (
+				<>
+					<Copy className="h-4 w-4" />
+					{loading ? 'Generating...' : 'Copy API Key'}
+				</>
+			)}
+		</Button>
+	);
 }


### PR DESCRIPTION
In Safari, the user's api key is generated, but `navigator.clipboard.writeText()` throws, so the user gets the 'key could not be generated or copied' notification. The older-browser fallback's never reached.

I think the [User Activation API doesn't regard this as a 'proper' user action](https://developer.apple.com/forums/thread/772275) hence failure, but it can be corrected, and the original fallback kept